### PR TITLE
Fix drift: Storage access tier, SQL TLS version, App Insights local auth

### DIFF
--- a/misc/database/sqldb.bicep
+++ b/misc/database/sqldb.bicep
@@ -12,7 +12,7 @@ resource sqlServer 'Microsoft.Sql/servers@2023-05-01-preview' = {
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
     version: '12.0'
-    minimalTlsVersion: '1.2'
+    minimalTlsVersion: '1.1'
     publicNetworkAccess: 'Enabled'
   }
 }

--- a/randomfolder/appinsights.bicep
+++ b/randomfolder/appinsights.bicep
@@ -12,6 +12,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
     IngestionMode: 'LogAnalytics'
     publicNetworkAccessForIngestion: 'Enabled'
     publicNetworkAccessForQuery: 'Enabled'
+    DisableLocalAuth: false
   }
 }
 

--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
## Summary
Fixes configuration drift detected across 3 Azure resources.

## Drift corrections
- **Microsoft.Storage/storageAccounts `mystorageacct001`**: `properties.accessTier` updated from **Hot** to **Cool**.
- **Microsoft.Sql/servers `mysqlserver-prod-xyz`**: `properties.minimumTlsVersion` updated from **1.2** to **1.1**.
- **Microsoft.Insights/components `appinsights-prod-main`**: `properties.DisableLocalAuth` set to **false** (was not set).

## Notes
- Compare branch (`drift-agent-eval-pr-1`) reflects the current/actual configuration; base branch (`main`) reflected the prior/expected state per the drift report.