### PR TITLE
Fix drift: storage account access tier for mystorageacct001

### DIFF
--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
## Drift corrected
- **Microsoft.Storage/storageAccounts/mystorageacct001**: updated `properties.accessTier` from **Hot** to **Cool** to match the current configuration.

## Files changed
- `storage.bicep`