### PR TITLE
Fix drift: mystorageacct001 access tier

### DIFF
--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
## Drift corrected
- **Microsoft.Storage/storageAccounts/mystorageacct001**: updated `properties.accessTier` from **Hot** (expected/old) to **Cool** (actual/new) to match the current deployed configuration.

## Notes
- No other resource/property drifts were reported in the provided drift report.