### PR TITLE
Fix drift: storage account mystorageacct001 accessTier

### DIFF
--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
## Drift corrected
- **Microsoft.Storage/storageAccounts/mystorageacct001**: aligned `properties.accessTier` from **Hot** (was expected in code) to **Cool** (actual in Azure).

## Files changed
- `storage.bicep`