### PR TITLE
Fix drift: storage account mystorageacct001 accessTier

### DIFF
--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
This PR fixes detected IaC drift for the following resource:

- **Microsoft.Storage/storageAccounts** `mystorageacct001`
  - Updated `properties.accessTier` from **Hot** (expected) to **Cool** (actual)

Only files changed between `main` (old) and `drift-agent-eval-pr-2` (new) are included.