### PR TITLE
Fix drift: mystorageacct001 accessTier to Cool

### DIFF
--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
This PR updates IaC to match the live configuration drift detected for the following resource:

- **Microsoft.Storage/storageAccounts/mystorageacct001**: `properties.accessTier` updated from **Hot** to **Cool**.
