### PR TITLE
Fix drift: nsg-web-tier, bettystoragemessy001, myVNet

### DIFF
--- a/nsg_rules.bicep
+++ b/nsg_rules.bicep
@@ -33,6 +33,20 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-05-0
         }
       }
       {
+        name: 'AllowSSH-Drift'
+        properties: {
+          access: 'Allow'
+          description: 'Drift testing SSH rule'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '22'
+          direction: 'Inbound'
+          priority: 200
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+        }
+      }
+      {
         name: 'DenyAllInbound'
         properties: {
           priority: 4096

--- a/old_stuff/network/vnet.bicep
+++ b/old_stuff/network/vnet.bicep
@@ -12,6 +12,10 @@ param subnets array = [
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   name: vnetName
   location: location
+  tags: {
+    Environment: 'Drift'
+    NetworkType: 'Modified'
+  }
   properties: {
     addressSpace: {
       addressPrefixes: [

--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
This PR updates IaC to match the current (drifted) state detected in Azure.

### Drift corrections
- **Microsoft.Network/networkSecurityGroups nsg-web-tier**: Adds inbound security rule `AllowSSH-Drift` (TCP/22, priority 200).
- **Microsoft.Storage/storageAccounts bettystoragemessy001**: Updates `accessTier` from **Hot** to **Cool**.
- **Microsoft.Network/virtualNetworks myVNet**: Adds VNet tags `Environment=Drift` and `NetworkType=Modified`.

### Files changed
- `old_stuff/network/vnet.bicep`
