### PR TITLE
Fix drift: mystorageacct001 storage account access tier

### DIFF
--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
Merges drift repairs from `drift-bot-eval-8` into `main` for repo `agent-eval-messy-bicep`.

Drift repairs applied:
- Microsoft.Storage/storageAccounts `mystorageacct001`
  - `properties.accessTier`: actual (fixed) = `Cool`, expected (drifted) = `Hot`