### PR TITLE
Fix drift: nsg-web-tier, bettystoragemessy001, myVNet

### DIFF
--- a/nsg_rules.bicep
+++ b/nsg_rules.bicep
@@ -33,16 +33,17 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-05-0
         }
       }
       {
-        name: 'DenyAllInbound'
+        name: 'AllowSSH-Drift'
         properties: {
-          priority: 4096
-          protocol: '*'
-          access: 'Deny'
+          access: 'Allow'
+          description: 'Drift testing SSH rule'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '22'
           direction: 'Inbound'
+          priority: 200
+          protocol: 'Tcp'
           sourceAddressPrefix: '*'
           sourcePortRange: '*'
-          destinationAddressPrefix: '*'
-          destinationPortRange: '*'
         }
       }
     ]

--- a/old_stuff/network/vnet.bicep
+++ b/old_stuff/network/vnet.bicep
@@ -12,6 +12,10 @@ param subnets array = [
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   name: vnetName
   location: location
+  tags: {
+    Environment: 'Drift'
+    NetworkType: 'Modified'
+  }
   properties: {
     addressSpace: {
       addressPrefixes: [

--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
Merge drift repairs from `drift-bot-eval-9` into `main` for repo `agent-eval-messy-bicep` (Org: `NL-EHV-BNNCMI-SOVPUBCLD`, Project: `project_name`).

Drift corrections applied:

1) Microsoft.Network/networkSecurityGroups `nsg-web-tier`
- `properties.securityRules.2`: expected `not set` -> actual `{ "name": "AllowSSH-Drift", "properties": { "access": "Allow", "description": "Drift testing SSH rule", "destinationAddressPrefix": "*", "destinationPortRange": "22", "direction": "Inbound", "priority": 200, "protocol": "Tcp", "sourceAddressPrefix": "*", "sourcePortRange": "*" } }`

2) Microsoft.Storage/storageAccounts `bettystoragemessy001`
- `properties.accessTier`: expected `Hot` -> actual `Cool`

3) Microsoft.Network/virtualNetworks `myVNet`
- `tags`: expected `not set` -> actual `{ "Environment": "Drift", "NetworkType": "Modified" }`