### PR TITLE
Fix drift: Storage, SQL server TLS, and App Insights auth

### DIFF
--- a/misc/database/sqldb.bicep
+++ b/misc/database/sqldb.bicep
@@ -12,7 +12,7 @@ resource sqlServer 'Microsoft.Sql/servers@2023-05-01-preview' = {
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
     version: '12.0'
-    minimalTlsVersion: '1.2'
+    minimalTlsVersion: '1.1'
     publicNetworkAccess: 'Enabled'
   }
 }

--- a/randomfolder/appinsights.bicep
+++ b/randomfolder/appinsights.bicep
@@ -8,6 +8,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   kind: 'web'
   properties: {
     Application_Type: 'web'
+    DisableLocalAuth: false
     WorkspaceResourceId: workspaceId
     IngestionMode: 'LogAnalytics'
     publicNetworkAccessForIngestion: 'Enabled'

--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
This PR repairs detected configuration drift in the following resources:

- Microsoft.Storage/storageAccounts mystorageacct001
  - properties.accessTier: set to "Cool" (actual/new) from "Hot" (expected/old)

- Microsoft.Sql/servers mysqlserver-prod-xyz
  - properties.minimumTlsVersion: set to "1.1" (actual/new) from "1.2" (expected/old)

- Microsoft.Insights/components appinsights-prod-main
  - properties.DisableLocalAuth: set to "false" (actual/new) from "not set" (expected/old)