### PR TITLE
Fix drift: storage account mystorageacct001 access tier

### DIFF
--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
This PR repairs detected configuration drift in the following resource:

- Microsoft.Storage/storageAccounts/mystorageacct001
  - properties.accessTier: set to "Cool" (actual/new) from "Hot" (expected/old)