### PR TITLE
Fix drift: storage account mystorageacct001 access tier

### DIFF
--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
Merging drift repairs from `drift-bot-eval-claude-2` into `main`.

Drift corrected:
- Microsoft.Storage/storageAccounts `mystorageacct001`
  - `properties.accessTier`: expected (old/drifted) `Hot` -> actual (new/fixed) `Cool`