### PR TITLE
Fix drift: NSG rule, storage access tier, VNet tags

### DIFF
--- a/nsg_rules.bicep
+++ b/nsg_rules.bicep
@@ -33,6 +33,20 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-05-0
         }
       }
       {
+        name: 'AllowSSH-Drift'
+        properties: {
+          access: 'Allow'
+          description: 'Drift testing SSH rule'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '22'
+          direction: 'Inbound'
+          priority: 200
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+        }
+      }
+      {
         name: 'DenyAllInbound'
         properties: {
           priority: 4096

--- a/old_stuff/network/vnet.bicep
+++ b/old_stuff/network/vnet.bicep
@@ -9,9 +9,12 @@ param subnets array = [
   }
 ]
 
+param tags object = {}
+
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   name: vnetName
   location: location
+  tags: tags
   properties: {
     addressSpace: {
       addressPrefixes: [

--- a/parameters.json
+++ b/parameters.json
@@ -22,6 +22,12 @@
           "addressPrefix": "10.1.2.0/24"
         }
       ]
+    },
+    "tags": {
+      "value": {
+        "Environment": "Drift",
+        "NetworkType": "Modified"
+      }
     }
   }
 }

--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
Merge drift repairs from `drift-bot-eval-claude-3` into `main` for repo `agent-eval-messy-bicep` (org: `NL-EHV-BNNCMI-SOVPUBCLD`, project: `project_name`).

Drift corrections applied:

1) Microsoft.Network/networkSecurityGroups `nsg-web-tier`
- `properties.securityRules.2`: expected (old/drifted) = not set; actual (new/fixed) = {"name":"AllowSSH-Drift","properties":{"access":"Allow","description":"Drift testing SSH rule","destinationAddressPrefix":"*","destinationPortRange":"22","direction":"Inbound","priority":200,"protocol":"Tcp","sourceAddressPrefix":"*","sourcePortRange":"*"}}

2) Microsoft.Storage/storageAccounts `bettystoragemessy001`
- `properties.accessTier`: expected (old/drifted) = Hot; actual (new/fixed) = Cool

3) Microsoft.Network/virtualNetworks `myVNet`
- `tags`: expected (old/drifted) = not set; actual (new/fixed) = {"Environment":"Drift","NetworkType":"Modified"}