### PR TITLE
Fix drift for storage account mystorageacct001 access tier

### DIFF
--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
## Summary
- Corrected `mystorageacct001` access tier drift by setting `properties.accessTier` to `Cool` (from `Hot`).

## Drift details
- **Microsoft.Storage/storageAccounts/mystorageacct001**
  - `properties.accessTier`: `Hot` → `Cool`