### PR TITLE
Fix drift: mystorageacct001 access tier

### DIFF
--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
## Summary
- Corrected configuration drift for `Microsoft.Storage/storageAccounts` `mystorageacct001` by setting `properties.accessTier` from `Hot` to `Cool`.

## Drift Details
- `properties.accessTier`: `Hot` → `Cool`
