### PR TITLE
Fix drift in NSG, storage account, and VNet

### DIFF
--- a/nsg_rules.bicep
+++ b/nsg_rules.bicep
@@ -33,6 +33,20 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-05-0
         }
       }
       {
+        name: 'AllowSSH-Drift'
+        properties: {
+          access: 'Allow'
+          description: 'Drift testing SSH rule'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '22'
+          direction: 'Inbound'
+          priority: 200
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+        }
+      }
+      {
         name: 'DenyAllInbound'
         properties: {
           priority: 4096

--- a/old_stuff/network/vnet.bicep
+++ b/old_stuff/network/vnet.bicep
@@ -12,6 +12,10 @@ param subnets array = [
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   name: vnetName
   location: location
+  tags: {
+    Environment: 'Drift'
+    NetworkType: 'Modified'
+  }
   properties: {
     addressSpace: {
       addressPrefixes: [

--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
## Summary
- add the `AllowSSH-Drift` inbound rule to `nsg-web-tier` to match the current security rule set
- update `bettystoragemessy001` access tier from Hot to Cool
- add `Environment=Drift` and `NetworkType=Modified` tags to `myVNet`

## Drift details
- `Microsoft.Network/networkSecurityGroups` `nsg-web-tier`: `properties.securityRules.2` updated from not set to the `AllowSSH-Drift` rule
- `Microsoft.Storage/storageAccounts` `bettystoragemessy001`: `properties.accessTier` updated from Hot to Cool
- `Microsoft.Network/virtualNetworks` `myVNet`: `tags` updated from not set to `{ Environment: Drift, NetworkType: Modified }`