### PR TITLE
Fix drift: storage access tier, SQL TLS, App Insights local auth

### DIFF
--- a/misc/database/sqldb.bicep
+++ b/misc/database/sqldb.bicep
@@ -12,7 +12,7 @@ resource sqlServer 'Microsoft.Sql/servers@2023-05-01-preview' = {
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
     version: '12.0'
-    minimalTlsVersion: '1.2'
+    minimalTlsVersion: '1.1'
     publicNetworkAccess: 'Enabled'
   }
 }

--- a/randomfolder/appinsights.bicep
+++ b/randomfolder/appinsights.bicep
@@ -8,8 +8,9 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   kind: 'web'
   properties: {
     Application_Type: 'web'
-    WorkspaceResourceId: workspaceId
+    DisableLocalAuth: false
     IngestionMode: 'LogAnalytics'
+    WorkspaceResourceId: workspaceId
     publicNetworkAccessForIngestion: 'Enabled'
     publicNetworkAccessForQuery: 'Enabled'
   }

--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
This PR fixes configuration drift detected in the following resources:

- **Microsoft.Storage/storageAccounts/mystorageacct001**
  - `properties.accessTier`: **Hot** → **Cool**
- **Microsoft.Sql/servers/mysqlserver-prod-xyz**
  - `properties.minimumTlsVersion`: **1.2** → **1.1**
- **Microsoft.Insights/components/appinsights-prod-main**
  - `properties.DisableLocalAuth`: **not set** → **false**
