### PR TITLE
Fix drift: nsg-web-tier rules, bettystoragemessy001 accessTier, myVNet tags

### DIFF
--- a/nsg_rules.bicep
+++ b/nsg_rules.bicep
@@ -33,6 +33,20 @@ resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-05-0
         }
       }
       {
+        name: 'AllowSSH-Drift'
+        properties: {
+          access: 'Allow'
+          description: 'Drift testing SSH rule'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '22'
+          direction: 'Inbound'
+          priority: 200
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+        }
+      }
+      {
         name: 'DenyAllInbound'
         properties: {
           priority: 4096

--- a/old_stuff/network/vnet.bicep
+++ b/old_stuff/network/vnet.bicep
@@ -12,6 +12,10 @@ param subnets array = [
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-05-01' = {
   name: vnetName
   location: location
+  tags: {
+    Environment: 'Drift'
+    NetworkType: 'Modified'
+  }
   properties: {
     addressSpace: {
       addressPrefixes: [

--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
## Drift corrected
This PR updates IaC definitions to match the current deployed state (drift-bot-eval-test-3 vs main) for the following resources:

- **Microsoft.Network/networkSecurityGroups/nsg-web-tier**: added inbound security rule `AllowSSH-Drift` (TCP/22, priority 200).
- **Microsoft.Storage/storageAccounts/bettystoragemessy001**: `accessTier` changed from **Hot** to **Cool**.
- **Microsoft.Network/virtualNetworks/myVNet**: tags added: `Environment=Drift`, `NetworkType=Modified`.

## Files changed
- `nsg_rules.bicep`
- `storage.bicep`
- `old_stuff/network/vnet.bicep`