### PR TITLE
Fix drift in storage, SQL, and App Insights settings

### DIFF
--- a/misc/database/sqldb.bicep
+++ b/misc/database/sqldb.bicep
@@ -12,7 +12,7 @@ resource sqlServer 'Microsoft.Sql/servers@2023-05-01-preview' = {
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
     version: '12.0'
-    minimalTlsVersion: '1.2'
+    minimalTlsVersion: '1.1'
     publicNetworkAccess: 'Enabled'
   }
 }

--- a/randomfolder/appinsights.bicep
+++ b/randomfolder/appinsights.bicep
@@ -8,6 +8,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   kind: 'web'
   properties: {
     Application_Type: 'web'
+    DisableLocalAuth: false
     WorkspaceResourceId: workspaceId
     IngestionMode: 'LogAnalytics'
     publicNetworkAccessForIngestion: 'Enabled'

--- a/storage.bicep
+++ b/storage.bicep
@@ -10,7 +10,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
   kind: 'StorageV2'
   properties: {
-    accessTier: 'Hot'
+    accessTier: 'Cool'
     supportsHttpsTrafficOnly: true
     minimumTlsVersion: 'TLS1_2'
   }


### PR DESCRIPTION
## Summary
- Set `mystorageacct001` access tier to `Cool`.
- Set `mysqlserver-prod-xyz` minimum TLS version to `1.1`.
- Set `appinsights-prod-main` DisableLocalAuth to `false`.

## Drift details
- `Microsoft.Storage/storageAccounts` `mystorageacct001`: `properties.accessTier` changed from `Hot` to `Cool`.
- `Microsoft.Sql/servers` `mysqlserver-prod-xyz`: `properties.minimumTlsVersion` changed from `1.2` to `1.1`.
- `Microsoft.Insights/components` `appinsights-prod-main`: `properties.DisableLocalAuth` set to `false` (was not set).